### PR TITLE
Avoid "Ignoring unsupported output" warning

### DIFF
--- a/Analysis/Smoothed_Plot_Profile.bsh
+++ b/Analysis/Smoothed_Plot_Profile.bsh
@@ -137,3 +137,4 @@ if (plot==null) return;
 plot.setPlotMaker(this);
 plot.show();
 firstRun = false;
+return;


### PR DESCRIPTION
Without the `return;` statement, the ImageJ2 console will display:
[WARNING] Ignoring unsupported output: result [java.lang.Boolean]
