### PR TITLE
Update to SciJava Maven repository

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@
 *.jar
 *.war
 *.ear
+/target/

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: java
-jdk: oraclejdk8
+jdk: openjdk8
 branches:
   only:
   - master

--- a/BAR/pom.xml
+++ b/BAR/pom.xml
@@ -15,7 +15,7 @@
 
 	<name>BAR</name>
 	<description>BAR: A curated collection of Broadly Applicable Routines for ImageJ.</description>
-	<url>http://imagej.net/BAR</url>
+	<url>https://imagej.net/BAR</url>
 	<inceptionYear>2014</inceptionYear>
 	<organization>
 		<name>Fiji</name>
@@ -49,21 +49,21 @@
 	<contributors>
 		<contributor>
 			<name>Mark Hiner</name>
-			<url>http://imagej.net/User:Hinerm</url>
+			<url>https://imagej.net/User:Hinerm</url>
 			<properties>
 				<id>hinerm</id>
 			</properties>
 		</contributor>
 		<contributor>
 			<name>Kota Miura</name>
-			<url>http://imagej.net/User:Miura</url>
+			<url>https://imagej.net/User:Miura</url>
 			<properties>
 				<id>cmci</id>
 			</properties>
 		</contributor>
 		<contributor>
 			<name>Jan Eglinger</name>
-			<url>http://imagej.net/User:Eglinger</url>
+			<url>https://imagej.net/User:Eglinger</url>
 			<properties>
 				<id>imagejan</id>
 			</properties>

--- a/BAR/pom.xml
+++ b/BAR/pom.xml
@@ -72,8 +72,8 @@
 
 	<mailingLists>
 		<mailingList>
-			<name>ImageJ Forum</name>
-			<archive>http://forum.imagej.net/</archive>
+			<name>Image.sc Forum</name>
+			<archive>https://forum.image.sc/tags/bar-scripts</archive>
 		</mailingList>
 	</mailingLists>
 

--- a/BAR/pom.xml
+++ b/BAR/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.scijava</groupId>
 		<artifactId>pom-scijava</artifactId>
-		<version>19.2.0</version>
+		<version>26.0.0</version>
 		<relativePath />
 	</parent>
 
@@ -99,10 +99,9 @@
 	</properties>
 
 	<repositories>
-		<!-- NB: for project parent -->
 		<repository>
-			<id>imagej.public</id>
-			<url>http://maven.imagej.net/content/groups/public</url>
+			<id>scijava.public</id>
+			<url>https://maven.scijava.org/content/groups/public</url>
 		</repository>
 	</repositories>
 

--- a/BAR/src/main/java/bar/FileDrop.java
+++ b/BAR/src/main/java/bar/FileDrop.java
@@ -12,12 +12,12 @@ import java.io.Reader;
  * a Java program. Any <tt>java.awt.Component</tt> can be dropped onto, but only
  * <tt>javax.swing.JComponent</tt>s will indicate the drop event with a changed
  * border.
- * <p/>
+ * <p>
  * To use this class, construct a new <tt>FileDrop</tt> by passing it the target
  * component and a <tt>Listener</tt> to receive notification when file(s) have
  * been dropped. Here is an example:
- * <p/>
- * <code><pre>
+ * </p>
+ * <pre>
  *      JPanel myPanel = new JPanel();
  *      new FileDrop( myPanel, new FileDrop.Listener()
  *      {   public void filesDropped( java.io.File[] files )
@@ -26,17 +26,18 @@ import java.io.Reader;
  *              ...
  *          }   // end filesDropped
  *      }); // end FileDrop.Listener
- * </pre></code>
- * <p/>
+ * </pre>
+ * <p>
  * You can specify the border that will appear when files are being dragged by
  * calling the constructor with a <tt>javax.swing.border.Border</tt>. Only
  * <tt>JComponent</tt>s will show any indication with a border.
- * <p/>
+ * </p>
+ * <p>
  * You can turn on some debugging features by passing a <tt>PrintStream</tt>
  * object (such as <tt>System.out</tt>) into the full constructor. A
  * <tt>null</tt> value will result in no extra debugging information being
  * output.
- * <p/>
+ * </p>
  *
  * <p>
  * I'm releasing this code into the Public Domain. Enjoy.
@@ -629,7 +630,8 @@ public class FileDrop {
 
 	/**
 	 * Implement this inner interface to listen for when files are dropped. For
-	 * example your class declaration may begin like this: <code><pre>
+	 * example your class declaration may begin like this:
+	 * <pre>
 	 *      public class MyClass implements FileDrop.Listener
 	 *      ...
 	 *      public void filesDropped( java.io.File[] files )
@@ -637,7 +639,7 @@ public class FileDrop {
 	 *          ...
 	 *      }   // end filesDropped
 	 *      ...
-	 * </pre></code>
+	 * </pre>
 	 *
 	 * @since 1.1
 	 */
@@ -712,12 +714,10 @@ public class FileDrop {
 	 * your object. For example:
 	 * 
 	 * <pre>
-	 * <code>
 	 *      ...
 	 *      MyCoolClass myObj = new MyCoolClass();
 	 *      Transferable xfer = new TransferableObject( myObj );
 	 *      ...
-	 * </code>
 	 * </pre>
 	 * 
 	 * Or if you need to know when the data was actually dropped, like when
@@ -726,7 +726,6 @@ public class FileDrop {
 	 * in Time. For example:
 	 * 
 	 * <pre>
-	 * <code>
 	 *      ...
 	 *      final MyCoolClass myObj = new MyCoolClass();
 	 * 
@@ -736,7 +735,6 @@ public class FileDrop {
 	 * 
 	 *      Transferable xfer = new TransferableObject( fetcher );
 	 *      ...
-	 * </code>
 	 * </pre>
 	 *
 	 * The {@link java.awt.datatransfer.DataFlavor} associated with

--- a/BAR/src/main/java/bar/plugin/ShenCastan.java
+++ b/BAR/src/main/java/bar/plugin/ShenCastan.java
@@ -30,8 +30,8 @@ import ij.process.ImageProcessor;
  * original manuscript: Shen and Castan, CVGIP, 1992, 54 (2) 112-133. <a
  * href="http://dx.doi.org/10.1016/1049-9652(92)90060-B">DOI:
  * 10.1016/1049-9652(92)90060-B</a>
- * <p>
- * <code><pre>
+ *
+ * <pre>
  * 2014.06-2015.07, Tiago Ferreira
  *      - Extended API
  *      - Works with 16-bit and 32-bit images and stacks (multithreaded)
@@ -42,7 +42,7 @@ import ij.process.ImageProcessor;
  *      - Algorithm implementation[1]. This initial version no longer works with IJ
  * 
  * [1] http://imagej.nih.gov/ij/plugins/inserm514/Documentation/Shen_Castan_514/Shen_Castan_514.html
- * </pre></code>
+ * </pre>
  */
 public class ShenCastan implements ExtendedPlugInFilter, DialogListener {
 

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.scijava</groupId>
 		<artifactId>pom-scijava</artifactId>
-		<version>19.2.0</version>
+		<version>26.0.0</version>
 		<relativePath />
 	</parent>
 


### PR DESCRIPTION
The maven.imagej.net repository became maven.scijava.org. This PR addresses that change, along with some other minor POM updates and improvements.